### PR TITLE
add dual-handle trim slider for review video

### DIFF
--- a/WebAnnotationEngine/src/routes/+layout.svelte
+++ b/WebAnnotationEngine/src/routes/+layout.svelte
@@ -1,34 +1,26 @@
 <script>
-	import '../app.css';
-
-	let isPopupVisible = false; // Controls the visibility of the popup
-
-	function togglePopup() {
-		isPopupVisible = !isPopupVisible;
-	}
+  import '../app.css';
 </script>
 
 <div class="drawer lg:drawer-open">
-	<input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
-	<div class="drawer-content">
-		<slot />
-		<label for="my-drawer-2" class="btn btn-primary drawer-button lg:hidden"> Open drawer </label>
-	</div>
-	<div class="drawer-side">
-		<label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay"></label>
-        <ul class="menu bg-base-200 text-base-content min-h-full w-20 p-0 flex flex-col items-center">
-            <div class="p-4">
-                <img class="size-20" src="/logo.svg" alt="Logo" />
-            </div>
-          
-            <!-- Home Link -->
-            <li class="w-full flex justify-center">
-                <a href="/" class="tooltip tooltip-right flex items-center justify-center" data-tip="Home">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-                  </svg>
-                </a>
-            </li>
-        </ul>
-	</div>
+  <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content">
+    <slot />
+    <label for="my-drawer-2" class="btn btn-primary drawer-button lg:hidden">Open drawer</label>
+  </div>
+  <div class="drawer-side">
+    <label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay"></label>
+    <ul class="menu bg-base-200 text-base-content min-h-full w-20 p-0 flex flex-col items-center">
+      <div class="p-4">
+        <img class="size-20" src="/logo.svg" alt="Logo" />
+      </div>
+      <li class="w-full flex justify-center">
+        <a href="/" class="tooltip tooltip-right flex items-center justify-center" data-tip="Home">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+          </svg>
+        </a>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/WebAnnotationEngine/src/routes/+page.svelte
+++ b/WebAnnotationEngine/src/routes/+page.svelte
@@ -20,7 +20,6 @@
 	let userToken = 0;
 
 	// Resume modal state
-	let showResumeModal = false;
 	let lastActivity = null;
 
 	// ---------- PROGRESS HELPERS ----------
@@ -136,20 +135,6 @@
 		}
 	}
 
-	function formatTimeAgo(timestamp) {
-		const now = Date.now();
-		const then = new Date(timestamp).getTime();
-		const diffMs = now - then;
-		const diffMins = Math.floor(diffMs / 60000);
-		const diffHours = Math.floor(diffMs / 3600000);
-		const diffDays = Math.floor(diffMs / 86400000);
-
-		if (diffMins < 1) return 'just now';
-		if (diffMins < 60) return `${diffMins} minute${diffMins > 1 ? 's' : ''} ago`;
-		if (diffHours < 24) return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
-		return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
-	}
-
 	// ---------- LIFECYCLE ----------
 
 	onMount(async () => {
@@ -247,121 +232,6 @@
 		goto(`/annotation/${encodeURIComponent(selectedBatch)}/${encodeURIComponent(word)}`);
 	}
 </script>
-
-<!-- Login Section -->
-{#if loading}
-	<div class="fixed inset-0 flex items-center justify-center bg-white">
-		<h2 class="text-2xl font-bold">Loading...</h2>
-	</div>
-{:else}
-	{#if !isLoggedIn}
-		<div class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
-			<div class="bg-white p-6 rounded shadow-lg">
-				<h2 class="text-lg">Enter your name to start annotating:</h2>
-				<input
-					type="text"
-					bind:value={username}
-					class="border p-2 rounded w-full"
-					placeholder="Enter your name..."
-					on:keypress={(event) => event.key === 'Enter' && saveUsername()}
-				/>
-				<button on:click={saveUsername} class="mt-4 bg-blue-500 text-white p-2 rounded w-full">
-					Start
-				</button>
-			</div>
-		</div>
-	{/if}
-
-	{#if isLoggedIn}
-		<div class="page-wrapper">
-			<!-- Header -->
-			<div class="header">
-				<h1 class="title">ASL Annotation</h1>
-				<div class="user-info">
-					<span>Hello, {username}</span>
-					<button on:click={logout} class="logout-button">Log Out</button>
-				</div>
-			</div>
-
-			<!-- Content -->
-			<div class="content-wrapper">
-				<!-- Resume Section -->
-				{#if lastActivity}
-					<div class="resume-section">
-						<div class="resume-header">Resume Where You Left Off</div>
-						<div class="resume-details">
-							<div class="resume-info">
-								<div class="resume-batch-word">
-									Batch: {lastActivity.batch} • Word: {lastActivity.word}
-								</div>
-							</div>
-							<div class="resume-actions">
-								<button class="btn-resume" on:click={resumeAnnotation}>Resume</button>
-								<button
-									class="btn-details"
-									on:click={() =>
-										goto(
-											`/summary/${encodeURIComponent(lastActivity.batch)}/${encodeURIComponent(lastActivity.word)}`
-										)}>View Details</button
-								>
-							</div>
-						</div>
-					</div>
-				{/if}
-
-				<!-- Batches and Words Grid -->
-				<div class="two-col">
-					<!-- Batch List -->
-					<div class="batch-list">
-						<h3>Batches</h3>
-						{#each batchList as b}
-							<div class="batch-item" on:click={() => selectBatch(b)}>
-								<div class="flex items-center justify-between">
-									<div>{b}</div>
-									<div class="meta">
-										{#if batchProgress[b]}
-											{batchProgress[b].done}/{batchProgress[b].total} • {batchProgress[b].percent}%
-										{:else}
-											loading…
-										{/if}
-									</div>
-								</div>
-								<div class="bar-bg mt-2">
-									<div class="bar-fill" style="width: {batchProgress[b]?.percent ?? 0}%"></div>
-								</div>
-							</div>
-						{/each}
-					</div>
-
-					<!-- Word List -->
-					<div class="word-list">
-						<h3>{selectedBatch ? `${selectedBatch} - Words` : 'Words'}</h3>
-						{#if selectedBatch}
-							{#each words as word}
-								<div class="word-item" on:click={() => startAnnotating(word)}>
-									<div class="flex items-center justify-between">
-										<div>{word}</div>
-										<div class="meta">
-											{#if wordProgress[word]}
-												{wordProgress[word].done}/{wordProgress[word].total} • {wordProgress[word]
-													.percent}%
-											{:else}
-												loading…
-											{/if}
-										</div>
-									</div>
-									<div class="bar-bg mt-2">
-										<div class="bar-fill" style="width: {wordProgress[word]?.percent ?? 0}%"></div>
-									</div>
-								</div>
-							{/each}
-						{/if}
-					</div>
-				</div>
-			</div>
-		</div>
-	{/if}
-{/if}
 
 <style>
 	.page-wrapper {
@@ -547,3 +417,119 @@
 		background: #f9fafb;
 	}
 </style>
+
+<!-- Login Section -->
+{#if loading}
+	<div class="fixed inset-0 flex items-center justify-center bg-white">
+		<h2 class="text-2xl font-bold">Loading...</h2>
+	</div>
+{:else}
+	{#if !isLoggedIn}
+		<div class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+			<div class="bg-white p-6 rounded shadow-lg">
+				<h2 class="text-lg">Enter your name to start annotating:</h2>
+				<input
+					type="text"
+					bind:value={username}
+					class="border p-2 rounded w-full"
+					placeholder="Enter your name..."
+					on:keypress={(event) => event.key === 'Enter' && saveUsername()}
+				/>
+				<button on:click={saveUsername} class="mt-4 bg-blue-500 text-white p-2 rounded w-full">
+					Start
+				</button>
+			</div>
+		</div>
+	{/if}
+
+	{#if isLoggedIn}
+		<div class="page-wrapper">
+			<!-- Header -->
+			<div class="header">
+				<h1 class="title">ASL Annotation</h1>
+				<div class="user-info">
+					<span>Hello, {username}</span>
+					<button on:click={logout} class="logout-button">Log Out</button>
+				</div>
+			</div>
+
+			<!-- Content -->
+			<div class="content-wrapper">
+				<!-- Resume Section -->
+				{#if lastActivity}
+					<div class="resume-section">
+						<div class="resume-header">Resume Where You Left Off</div>
+						<div class="resume-details">
+							<div class="resume-info">
+								<div class="resume-batch-word">
+									Batch: {lastActivity.batch} • Word: {lastActivity.word}
+								</div>
+							</div>
+							<div class="resume-actions">
+								<button class="btn-resume" on:click={resumeAnnotation}>Resume</button>
+								<button
+									class="btn-details"
+									on:click={() =>
+										goto(
+											`/summary/${encodeURIComponent(lastActivity.batch)}/${encodeURIComponent(lastActivity.word)}`
+										)}>View Details</button
+								>
+							</div>
+						</div>
+					</div>
+				{/if}
+
+				<!-- Batches and Words Grid -->
+				<div class="two-col">
+					<!-- Batch List -->
+					<div class="batch-list">
+						<h3>Batches</h3>
+						{#each batchList as b}
+							<div class="batch-item" on:click={() => selectBatch(b)}>
+								<div class="flex items-center justify-between">
+									<div>{b}</div>
+									<div class="meta">
+										{#if batchProgress[b]}
+											{batchProgress[b].done}/{batchProgress[b].total} • {batchProgress[b].percent}%
+										{:else}
+											loading…
+										{/if}
+									</div>
+								</div>
+								<div class="bar-bg mt-2">
+									<div class="bar-fill" style="width: {batchProgress[b]?.percent ?? 0}%"></div>
+								</div>
+							</div>
+						{/each}
+					</div>
+
+					<!-- Word List -->
+					<div class="word-list">
+						<h3>{selectedBatch ? `${selectedBatch} - Words` : 'Words'}</h3>
+						{#if selectedBatch}
+							{#each words as word}
+								<div class="word-item" on:click={() => startAnnotating(word)}>
+									<div class="flex items-center justify-between">
+										<div>{word}</div>
+										<div class="meta">
+											{#if wordProgress[word]}
+												{wordProgress[word].done}/{wordProgress[word].total} • {wordProgress[word]
+													.percent}%
+											{:else}
+												loading…
+											{/if}
+										</div>
+									</div>
+									<div class="bar-bg mt-2">
+										<div class="bar-fill" style="width: {wordProgress[word]?.percent ?? 0}%"></div>
+									</div>
+								</div>
+							{/each}
+						{/if}
+					</div>
+				</div>
+			</div>
+		</div>
+	{/if}
+{/if}
+

--- a/WebAnnotationEngine/src/routes/+page.svelte
+++ b/WebAnnotationEngine/src/routes/+page.svelte
@@ -1,535 +1,534 @@
 <script>
-	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
 
-	let username = null;
-	let isLoggedIn = false;
-	let loading = true;
+  let username = null;
+  let isLoggedIn = false;
+  let loading = true;
 
-	let batches = {};
-	let batchList = [];
-	let words = [];
-	let selectedBatch = null;
+  let batches = {};
+  let batchList = [];
+  let words = [];
+  let selectedBatch = null;
 
-	const API_BASE = 'http://127.0.0.1:5000';
-	const basename = (p) => (p || '').split('/').pop();
+  const API_BASE = 'http://127.0.0.1:5000';
+  const basename = (p) => (p || '').split('/').pop();
 
-	let wordProgress = {};
-	let batchProgress = {};
+  let wordProgress = {};
+  let batchProgress = {};
 
-	let userToken = 0;
+  let userToken = 0;
 
-	// Resume modal state
-	let lastActivity = null;
+  // Resume modal state
+  let lastActivity = null;
 
-	// ---------- PROGRESS HELPERS ----------
+  // PROGRESS HELPERS
 
-	async function loadProgressForWord(batch, word, uname, token) {
-		if (!uname) return;
+  async function loadProgressForWord(batch, word, uname, token) {
+    if (!uname) return;
 
-		const entry = batches?.[batch]?.[word];
-		const reviews = entry?.reviews || [];
-		const total = reviews.length;
+    const entry = batches?.[batch]?.[word];
+    const reviews = entry?.reviews || [];
+    const total = reviews.length;
 
-		if (!total) {
-			if (token !== userToken) return;
-			wordProgress[word] = { done: 0, total: 0, percent: 0 };
-			return;
-		}
+    if (!total) {
+      if (token !== userToken) return;
+      wordProgress[word] = { done: 0, total: 0, percent: 0 };
+      return;
+    }
 
-		const KEY = `wp:${uname}:${batch}:${word}`;
-		const cached = localStorage.getItem(KEY);
-		if (cached) {
-			try {
-				const parsed = JSON.parse(cached);
-				if (token === userToken) wordProgress[word] = parsed;
-			} catch {}
-		}
+    const KEY = `wp:${uname}:${batch}:${word}`;
+    const cached = localStorage.getItem(KEY);
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached);
+        if (token === userToken) wordProgress[word] = parsed;
+      } catch {}
+    }
 
-		try {
-			const res = await fetch(
-				`${API_BASE}/annots?user=${encodeURIComponent(uname)}&sign=${encodeURIComponent(word)}`
-			);
-			if (!res.ok) return;
+    try {
+      const res = await fetch(
+        `${API_BASE}/annots?user=${encodeURIComponent(uname)}&sign=${encodeURIComponent(word)}`
+      );
+      if (!res.ok) return;
 
-			const saved = await res.json();
-			const baseSet = new Set(reviews.map(basename));
+      const saved = await res.json();
+      const baseSet = new Set(reviews.map(basename));
 
-			let done = 0;
-			for (const f of Object.keys(saved)) {
-				if (baseSet.has(f) && saved[f]?.label && String(saved[f].label).trim() !== '') {
-					done++;
-				}
-			}
+      let done = 0;
+      for (const f of Object.keys(saved)) {
+        if (baseSet.has(f) && saved[f]?.label && String(saved[f].label).trim() !== '') {
+          done++;
+        }
+      }
 
-			const percent = total ? Math.round((done / total) * 100) : 0;
+      const percent = total ? Math.round((done / total) * 100) : 0;
 
-			if (token !== userToken) return;
+      if (token !== userToken) return;
 
-			wordProgress[word] = { done, total, percent };
-			localStorage.setItem(KEY, JSON.stringify(wordProgress[word]));
-		} catch (e) {
-			if (token === userToken) console.warn('progress fetch failed:', word, e);
-		}
-	}
+      wordProgress[word] = { done, total, percent };
+      localStorage.setItem(KEY, JSON.stringify(wordProgress[word]));
+    } catch (e) {
+      if (token === userToken) console.warn('progress fetch failed:', word, e);
+    }
+  }
 
-	function computeBatchProgress(batch) {
-		const keys = Object.keys(batches[batch] || {});
-		let done = 0, total = 0;
+  function computeBatchProgress(batch) {
+    const keys = Object.keys(batches[batch] || {});
+    let done = 0, total = 0;
 
-		for (const w of keys) {
-			const wp = wordProgress[w];
-			if (wp) {
-				done += wp.done || 0;
-				total += wp.total || 0;
-			}
-		}
-		const percent = total ? Math.round((done / total) * 100) : 0;
-		batchProgress[batch] = { done, total, percent };
-	}
+    for (const w of keys) {
+      const wp = wordProgress[w];
+      if (wp) {
+        done += wp.done || 0;
+        total += wp.total || 0;
+      }
+    }
+    const percent = total ? Math.round((done / total) * 100) : 0;
+    batchProgress[batch] = { done, total, percent };
+  }
 
-	async function loadAllWordProgress(batch, uname, token) {
-		if (!batch || !uname) return;
-		const ws = Object.keys(batches[batch] || {});
-		await Promise.all(ws.map((w) => loadProgressForWord(batch, w, uname, token)));
-		if (token === userToken) computeBatchProgress(batch);
-	}
+  async function loadAllWordProgress(batch, uname, token) {
+    if (!batch || !uname) return;
+    const ws = Object.keys(batches[batch] || {});
+    await Promise.all(ws.map((w) => loadProgressForWord(batch, w, uname, token)));
+    if (token === userToken) computeBatchProgress(batch);
+  }
 
-	async function loadAllBatchesProgress(uname, token) {
-		if (!uname) return;
-		for (const b of batchList) {
-			await loadAllWordProgress(b, uname, token);
-		}
-	}
+  async function loadAllBatchesProgress(uname, token) {
+    if (!uname) return;
+    for (const b of batchList) {
+      await loadAllWordProgress(b, uname, token);
+    }
+  }
 
-	// ---------- RESUME HELPERS ----------
+  // RESUME HELPERS
 
-	function checkForLastActivity() {
-		if (!username) return;
+  function checkForLastActivity() {
+    if (!username) return;
 
-		const key = `lastActivity:${username}`;
-		const stored = localStorage.getItem(key);
+    const key = `lastActivity:${username}`;
+    const stored = localStorage.getItem(key);
 
-		if (stored) {
-			try {
-				const activity = JSON.parse(stored);
-				// Check if activity is recent (within last 7 days)
-				const activityDate = new Date(activity.timestamp);
-				const daysSince = (Date.now() - activityDate.getTime()) / (1000 * 60 * 60 * 24);
+    if (stored) {
+      try {
+        const activity = JSON.parse(stored);
+        // Check if activity is recent (within last 7 days)
+        const activityDate = new Date(activity.timestamp);
+        const daysSince = (Date.now() - activityDate.getTime()) / (1000 * 60 * 60 * 24);
 
-				if (daysSince < 7) {
-					lastActivity = activity;
-				}
-			} catch (e) {
-				console.warn('Failed to parse last activity', e);
-			}
-		}
-	}
+        if (daysSince < 7) {
+          lastActivity = activity;
+        }
+      } catch (e) {
+        console.warn('Failed to parse last activity', e);
+      }
+    }
+  }
 
-	function resumeAnnotation() {
-		if (lastActivity) {
-			// Navigate to the exact video using the video parameter
-			goto(
-				`/annotation/${encodeURIComponent(lastActivity.batch)}/${encodeURIComponent(lastActivity.word)}?video=${encodeURIComponent(lastActivity.video)}`
-			);
-		}
-	}
+  function resumeAnnotation() {
+    if (lastActivity) {
+      // Navigate to the exact video using the video parameter
+      goto(
+        `/annotation/${encodeURIComponent(lastActivity.batch)}/${encodeURIComponent(lastActivity.word)}?video=${encodeURIComponent(lastActivity.video)}`
+      );
+    }
+  }
 
-	// ---------- LIFECYCLE ----------
+  // LIFECYCLE
 
-	onMount(async () => {
-		const storedUsername = typeof window !== 'undefined' ? (localStorage.getItem('username') || '').trim() : '';
+  onMount(async () => {
+    const storedUsername = typeof window !== 'undefined' ? (localStorage.getItem('username') || '').trim() : '';
 
-		if (storedUsername) {
-			username = storedUsername;
-			isLoggedIn = true;
-			userToken++;
-			wordProgress = {};
-			batchProgress = {};
-		}
+    if (storedUsername) {
+      username = storedUsername;
+      isLoggedIn = true;
+      userToken++;
+      wordProgress = {};
+      batchProgress = {};
+    }
 
-		loading = false;
+    loading = false;
 
-		try {
-			const response = await fetch(`${API_BASE}/api/batches`);
-			if (!response.ok) throw new Error('Failed to load batches');
-			batches = await response.json();
-			batchList = Object.keys(batches);
+    try {
+      const response = await fetch(`${API_BASE}/api/batches`);
+      if (!response.ok) throw new Error('Failed to load batches');
+      batches = await response.json();
+      batchList = Object.keys(batches);
 
-			if (!selectedBatch && batchList.length) {
-				selectedBatch = batchList[0];
-				words = Object.keys(batches[selectedBatch]);
-			}
+      if (!selectedBatch && batchList.length) {
+        selectedBatch = batchList[0];
+        words = Object.keys(batches[selectedBatch]);
+      }
 
-			if (isLoggedIn && username) {
-				const token = userToken;
-				await loadAllWordProgress(selectedBatch, username, token);
-				await loadAllBatchesProgress(username, token);
+      if (isLoggedIn && username) {
+        const token = userToken;
+        await loadAllWordProgress(selectedBatch, username, token);
+        await loadAllBatchesProgress(username, token);
 
-				// Check for last activity after loading batches
-				checkForLastActivity();
-			}
-		} catch (error) {
-			console.error('Error loading batches:', error);
-		}
-	});
+        // Check for last activity after loading batches
+        checkForLastActivity();
+      }
+    } catch (error) {
+      console.error('Error loading batches:', error);
+    }
+  });
 
-	// ---------- AUTH ----------
+  // AUTH
 
-	async function saveUsername() {
-		const next = (username || '').trim();
-		if (next === '') return;
+  async function saveUsername() {
+    const next = (username || '').trim();
+    if (next === '') return;
 
-		const res = await fetch(`${API_BASE}/check_user`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ username: next })
-		});
+    const res = await fetch(`${API_BASE}/check_user`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: next })
+    });
 
-		const data = await res.json();
+    const data = await res.json();
 
-		if (data.valid) {
-			localStorage.setItem('username', next);
-			isLoggedIn = true;
+    if (data.valid) {
+      localStorage.setItem('username', next);
+      isLoggedIn = true;
 
-			userToken++;
-			wordProgress = {};
-			batchProgress = {};
+      userToken++;
+      wordProgress = {};
+      batchProgress = {};
 
-			const token = userToken;
-			await loadAllWordProgress(selectedBatch, next, token);
-		} else {
-			alert('Username not recognized. Please contact an admin.');
-		}
-	}
+      const token = userToken;
+      await loadAllWordProgress(selectedBatch, next, token);
+    } else {
+      alert('Username not recognized. Please contact an admin.');
+    }
+  }
 
-	function logout() {
-		localStorage.removeItem('username');
-		isLoggedIn = false;
-		username = null;
+  function logout() {
+    localStorage.removeItem('username');
+    isLoggedIn = false;
+    username = null;
 
-		userToken++;
-		wordProgress = {};
-		batchProgress = {};
-	}
+    userToken++;
+    wordProgress = {};
+    batchProgress = {};
+  }
 
-	// ---------- UI ACTIONS ----------
+  // ---------- UI ACTIONS ----------
 
-	function selectBatch(batch) {
-		selectedBatch = batch;
-		words = Object.keys(batches[batch]);
-		if (isLoggedIn && username) {
-			const token = userToken;
-			loadAllWordProgress(batch, username, token);
-		}
-	}
+  function selectBatch(batch) {
+    selectedBatch = batch;
+    words = Object.keys(batches[batch]);
+    if (isLoggedIn && username) {
+      const token = userToken;
+      loadAllWordProgress(batch, username, token);
+    }
+  }
 
-	function startAnnotating(word) {
-		if (!isLoggedIn) {
-			alert('Please enter your name to start annotating.');
-			return;
-		}
-		goto(`/annotation/${encodeURIComponent(selectedBatch)}/${encodeURIComponent(word)}`);
-	}
+  function startAnnotating(word) {
+    if (!isLoggedIn) {
+      alert('Please enter your name to start annotating.');
+      return;
+    }
+    goto(`/annotation/${encodeURIComponent(selectedBatch)}/${encodeURIComponent(word)}`);
+  }
 </script>
-
-<style>
-	.page-wrapper {
-		display: flex;
-		flex-direction: column;
-		height: 100vh;
-		overflow: hidden;
-	}
-
-	.header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 1.5rem 2rem 1rem 2rem;
-		flex-shrink: 0;
-	}
-
-	.title {
-		font-size: 2.5rem;
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-			'Cantarell', sans-serif;
-		font-weight: 600;
-		color: #1f2937;
-		margin: 0;
-	}
-
-	.user-info {
-		display: flex;
-		align-items: center;
-		gap: 10px;
-		background: rgba(0, 0, 0, 0.1);
-		padding: 8px 16px;
-		border-radius: 8px;
-		font-size: 1rem;
-		font-weight: bold;
-	}
-
-	.logout-button {
-		background: red;
-		color: white;
-		border: none;
-		padding: 6px 12px;
-		border-radius: 6px;
-		cursor: pointer;
-	}
-
-	.logout-button:hover {
-		background: darkred;
-	}
-
-	.content-wrapper {
-		flex: 1;
-		overflow-y: auto;
-		padding: 0 2rem 2rem 2rem;
-	}
-
-	/* Batches Card Styles */
-	.two-col {
-		display: flex;
-		width: 100%;
-		gap: 1rem;
-		margin-top: 1rem;
-    align-items: stretch;
-	}
-
-	.batch-list,
-	.word-list {
-		flex: 1;
-		background-color: #f3f4f6;
-		border: 2px solid #e5e7eb;
-		border-radius: 0.5rem;
-		padding: 1.5rem;
-		overflow-y: auto;
-    min-width: 0;
-		max-height: 100%;
-	}
-
-	.batch-item,
-	.word-item {
-		padding: 0.5rem;
-		margin: 0.5rem 0;
-		background-color: #e5e7eb;
-		border-radius: 0.5rem;
-		cursor: pointer;
-		text-align: center;
-		transition: all 0.2s;
-	}
-
-	.batch-item:hover,
-	.word-item:hover {
-		background-color: #d1d5db;
-		transform: translateX(4px);
-	}
-
-	.meta {
-		font-size: 12px;
-		color: #4b5563;
-	}
-  
-	.bar-bg {
-		height: 6px;
-		background: #e5e7eb;
-		border-radius: 6px;
-    width: 100%;
-	}
-
-	.bar-fill {
-		height: 6px;
-		background: #3b82f6;
-		border-radius: 6px;
-		transition: width 160ms linear;
-	}
-
-	h3 {
-		margin-top: 0;
-	}
-
-	/* Resume Card Styles */
-	.resume-section {
-		background: #f3f4f6;
-		border: 2px solid #e5e7eb;
-		border-radius: 0.5rem;
-		padding: 1.5rem;
-		margin-bottom: 1rem;
-	}
-
-	.resume-header {
-		font-size: 1.125rem;
-		font-weight: 600;
-		color: #1f2937;
-		margin-bottom: 0.5rem;
-	}
-
-	.resume-details {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 1rem;
-	}
-
-	.resume-info {
-		flex: 1;
-	}
-
-	.resume-batch-word {
-		font-size: 1rem;
-		color: #1f2937;
-	}
-
-	.resume-actions {
-		display: flex;
-		gap: 0.75rem;
-	}
-
-	.btn-resume {
-		background: #3b82f6;
-		color: white;
-		border: none;
-		padding: 0.5rem 1.5rem;
-		border-radius: 0.5rem;
-		cursor: pointer;
-		transition: background 0.2s;
-		font-size: 1rem;
-	}
-
-	.btn-resume:hover {
-		background: #2563eb;
-	}
-
-	.btn-details {
-		background: white;
-		color: #4b5563;
-		border: 2px solid #e5e7eb;
-		padding: 0.5rem 1.5rem;
-		border-radius: 0.5rem;
-		cursor: pointer;
-		transition: all 0.2s;
-		font-size: 1rem;
-	}
-
-	.btn-details:hover {
-		border-color: #d1d5db;
-		background: #f9fafb;
-	}
-</style>
 
 <!-- Login Section -->
 {#if loading}
-	<div class="fixed inset-0 flex items-center justify-center bg-white">
-		<h2 class="text-2xl font-bold">Loading...</h2>
-	</div>
+  <div class="fixed inset-0 flex items-center justify-center bg-white">
+    <h2 class="text-2xl font-bold">Loading...</h2>
+  </div>
 {:else}
-	{#if !isLoggedIn}
-		<div class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
-			<div class="bg-white p-6 rounded shadow-lg">
-				<h2 class="text-lg">Enter your name to start annotating:</h2>
-				<input
-					type="text"
-					bind:value={username}
-					class="border p-2 rounded w-full"
-					placeholder="Enter your name..."
-					on:keypress={(event) => event.key === 'Enter' && saveUsername()}
-				/>
-				<button on:click={saveUsername} class="mt-4 bg-blue-500 text-white p-2 rounded w-full">
-					Start
-				</button>
-			</div>
-		</div>
-	{/if}
+  {#if !isLoggedIn}
+    <div class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50">
+      <div class="bg-white p-6 rounded shadow-lg">
+        <h2 class="text-lg">Enter your name to start annotating:</h2>
+        <input
+          type="text"
+          bind:value={username}
+          class="border p-2 rounded w-full"
+          placeholder="Enter your name..."
+          on:keypress={(event) => event.key === 'Enter' && saveUsername()}
+        />
+        <button on:click={saveUsername} class="mt-4 bg-blue-500 text-white p-2 rounded w-full">
+          Start
+        </button>
+      </div>
+    </div>
+  {/if}
 
-	{#if isLoggedIn}
-		<div class="page-wrapper">
-			<!-- Header -->
-			<div class="header">
-				<h1 class="title">ASL Annotation</h1>
-				<div class="user-info">
-					<span>Hello, {username}</span>
-					<button on:click={logout} class="logout-button">Log Out</button>
-				</div>
-			</div>
+  {#if isLoggedIn}
+    <div class="page-wrapper">
+      <!-- Header -->
+      <div class="header">
+        <h1 class="title">ASL Annotation</h1>
+        <div class="user-info">
+          <span>Hello, {username}</span>
+          <button on:click={logout} class="logout-button">Log Out</button>
+        </div>
+      </div>
 
-			<!-- Content -->
-			<div class="content-wrapper">
-				<!-- Resume Section -->
-				{#if lastActivity}
-					<div class="resume-section">
-						<div class="resume-header">Resume Where You Left Off</div>
-						<div class="resume-details">
-							<div class="resume-info">
-								<div class="resume-batch-word">
-									Batch: {lastActivity.batch} • Word: {lastActivity.word}
-								</div>
-							</div>
-							<div class="resume-actions">
-								<button class="btn-resume" on:click={resumeAnnotation}>Resume</button>
-								<button
-									class="btn-details"
-									on:click={() =>
-										goto(
-											`/summary/${encodeURIComponent(lastActivity.batch)}/${encodeURIComponent(lastActivity.word)}`
-										)}>View Details</button
-								>
-							</div>
-						</div>
-					</div>
-				{/if}
+      <!-- Content -->
+      <div class="content-wrapper">
+        <!-- Resume Section -->
+        {#if lastActivity}
+          <div class="resume-section">
+            <div class="resume-header">Resume Where You Left Off</div>
+            <div class="resume-details">
+              <div class="resume-info">
+                <div class="resume-batch-word">
+                  Batch: {lastActivity.batch} • Word: {lastActivity.word}
+                </div>
+              </div>
+              <div class="resume-actions">
+                <button class="btn-resume" on:click={resumeAnnotation}>Resume</button>
+                <button
+                  class="btn-details"
+                  on:click={() =>
+                    goto(
+                      `/summary/${encodeURIComponent(lastActivity.batch)}/${encodeURIComponent(lastActivity.word)}`
+                    )}>View Details</button
+                >
+              </div>
+            </div>
+          </div>
+        {/if}
 
-				<!-- Batches and Words Grid -->
-				<div class="two-col">
-					<!-- Batch List -->
-					<div class="batch-list">
-						<h3>Batches</h3>
-						{#each batchList as b}
-							<div class="batch-item" on:click={() => selectBatch(b)}>
-								<div class="flex items-center justify-between">
-									<div>{b}</div>
-									<div class="meta">
-										{#if batchProgress[b]}
-											{batchProgress[b].done}/{batchProgress[b].total} • {batchProgress[b].percent}%
-										{:else}
-											loading…
-										{/if}
-									</div>
-								</div>
-								<div class="bar-bg mt-2">
-									<div class="bar-fill" style="width: {batchProgress[b]?.percent ?? 0}%"></div>
-								</div>
-							</div>
-						{/each}
-					</div>
+        <!-- Batches and Words Grid -->
+        <div class="two-col">
+          <!-- Batch List -->
+          <div class="batch-list">
+            <h3>Batches</h3>
+            {#each batchList as b}
+              <div class="batch-item" on:click={() => selectBatch(b)}>
+                <div class="flex items-center justify-between">
+                  <div>{b}</div>
+                  <div class="meta">
+                    {#if batchProgress[b]}
+                      {batchProgress[b].done}/{batchProgress[b].total} • {batchProgress[b].percent}%
+                    {:else}
+                      loading…
+                    {/if}
+                  </div>
+                </div>
+                <div class="bar-bg mt-2">
+                  <div class="bar-fill" style="width: {batchProgress[b]?.percent ?? 0}%"></div>
+                </div>
+              </div>
+            {/each}
+          </div>
 
-					<!-- Word List -->
-					<div class="word-list">
-						<h3>{selectedBatch ? `${selectedBatch} - Words` : 'Words'}</h3>
-						{#if selectedBatch}
-							{#each words as word}
-								<div class="word-item" on:click={() => startAnnotating(word)}>
-									<div class="flex items-center justify-between">
-										<div>{word}</div>
-										<div class="meta">
-											{#if wordProgress[word]}
-												{wordProgress[word].done}/{wordProgress[word].total} • {wordProgress[word]
-													.percent}%
-											{:else}
-												loading…
-											{/if}
-										</div>
-									</div>
-									<div class="bar-bg mt-2">
-										<div class="bar-fill" style="width: {wordProgress[word]?.percent ?? 0}%"></div>
-									</div>
-								</div>
-							{/each}
-						{/if}
-					</div>
-				</div>
-			</div>
-		</div>
-	{/if}
+          <!-- Word List -->
+          <div class="word-list">
+            <h3>{selectedBatch ? `${selectedBatch} - Words` : 'Words'}</h3>
+            {#if selectedBatch}
+              {#each words as word}
+                <div class="word-item" on:click={() => startAnnotating(word)}>
+                  <div class="flex items-center justify-between">
+                    <div>{word}</div>
+                    <div class="meta">
+                      {#if wordProgress[word]}
+                        {wordProgress[word].done}/{wordProgress[word].total} • {wordProgress[word]
+                          .percent}%
+                      {:else}
+                        loading…
+                      {/if}
+                    </div>
+                  </div>
+                  <div class="bar-bg mt-2">
+                    <div class="bar-fill" style="width: {wordProgress[word]?.percent ?? 0}%"></div>
+                  </div>
+                </div>
+              {/each}
+            {/if}
+          </div>
+        </div>
+      </div>
+    </div>
+  {/if}
 {/if}
 
+<style>
+  .page-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.5rem 2rem 1rem 2rem;
+    flex-shrink: 0;
+  }
+
+  .title {
+    font-size: 2.5rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+      'Cantarell', sans-serif;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0;
+  }
+
+  .user-info {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(0, 0, 0, 0.1);
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: bold;
+  }
+
+  .logout-button {
+    background: red;
+    color: white;
+    border: none;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+
+  .logout-button:hover {
+    background: darkred;
+  }
+
+  .content-wrapper {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 2rem 2rem 2rem;
+  }
+
+  /* Batches Card Styles */
+  .two-col {
+    display: flex;
+    width: 100%;
+    gap: 1rem;
+    margin-top: 1rem;
+    align-items: stretch;
+  }
+
+  .batch-list,
+  .word-list {
+    flex: 1;
+    background-color: #f3f4f6;
+    border: 2px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    overflow-y: auto;
+    min-width: 0;
+    max-height: 100%;
+  }
+
+  .batch-item,
+  .word-item {
+    padding: 0.5rem;
+    margin: 0.5rem 0;
+    background-color: #e5e7eb;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    text-align: center;
+    transition: all 0.2s;
+  }
+
+  .batch-item:hover,
+  .word-item:hover {
+    background-color: #d1d5db;
+    transform: translateX(4px);
+  }
+
+  .meta {
+    font-size: 12px;
+    color: #4b5563;
+  }
+  
+  .bar-bg {
+    height: 6px;
+    background: #e5e7eb;
+    border-radius: 6px;
+    width: 100%;
+  }
+
+  .bar-fill {
+    height: 6px;
+    background: #3b82f6;
+    border-radius: 6px;
+    transition: width 160ms linear;
+  }
+
+  h3 {
+    margin-top: 0;
+  }
+
+  /* Resume Card Styles */
+  .resume-section {
+    background: #f3f4f6;
+    border: 2px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .resume-header {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 0.5rem;
+  }
+
+  .resume-details {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .resume-info {
+    flex: 1;
+  }
+
+  .resume-batch-word {
+    font-size: 1rem;
+    color: #1f2937;
+  }
+
+  .resume-actions {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .btn-resume {
+    background: #3b82f6;
+    color: white;
+    border: none;
+    padding: 0.5rem 1.5rem;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: background 0.2s;
+    font-size: 1rem;
+  }
+
+  .btn-resume:hover {
+    background: #2563eb;
+  }
+
+  .btn-details {
+    background: white;
+    color: #4b5563;
+    border: 2px solid #e5e7eb;
+    padding: 0.5rem 1.5rem;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    font-size: 1rem;
+  }
+
+  .btn-details:hover {
+    border-color: #d1d5db;
+    background: #f9fafb;
+  }
+</style>

--- a/WebAnnotationEngine/src/routes/annotation/[batch]/[word]/+page.svelte
+++ b/WebAnnotationEngine/src/routes/annotation/[batch]/[word]/+page.svelte
@@ -3,44 +3,40 @@
   import { browser } from '$app/environment';
   import { onMount } from 'svelte';
   import { Pane, Splitpanes } from 'svelte-splitpanes';
-  import {writable} from "svelte/store";
+  import { writable } from 'svelte/store';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
 
-  export const userAnnot = writable({})
+  export const userAnnot = writable({});
 
   const { batch, word, selectedVideoData } = data;
-  const API_BASE = "http://127.0.0.1:5000";
-  const basename = (p) => (p || "").split("/").pop();
-  const username = (localStorage.getItem("username") || "").trim();
+  const API_BASE = 'http://127.0.0.1:5000';
+  const basename = (p) => (p || '').split('/').pop();
+  const username = (localStorage.getItem('username') || '').trim();
   const toFlask = (p) => {
-    const clean = p.replace(/^\/?/, "");
+    const clean = p.replace(/^\/?/, '');
     return `${API_BASE}/${encodeURI(clean)}`;
   };
 
   onMount(async () => {
     if (!username || !selectedVideoData?.reviews?.length) return;
 
-    const url = $page.url; // SvelteKit store value
-    const qVideo = url.searchParams.get('video');
-
+    const qVideo = $page.url.searchParams.get('video');
     if (qVideo) {
-      const i = selectedVideoData.reviews.findIndex(p =>
-        p === qVideo || basename(p) === basename(qVideo)
+      const i = selectedVideoData.reviews.findIndex(
+        (p) => p === qVideo || basename(p) === basename(qVideo)
       );
       if (i >= 0) currReviewVideo = i;
     }
 
-    const res = await fetch(
-      `${API_BASE}/annots?user=${encodeURIComponent(username)}&sign=${encodeURIComponent(word)}`
-    );
+    const res = await fetch(`${API_BASE}/annots?user=${username}&sign=${word}`);
     if (!res.ok) return;
-    const saved = await res.json(); 
+    const saved = await res.json();
     const next = {};
     selectedVideoData.reviews.forEach((p, idx) => {
       const a = saved[basename(p)];
-      if (a && a.label) {
-        next[idx] = { annot_label: a.label, annot_comments: a.comments || "" };
+      if (a?.label) {
+        next[idx] = { annot_label: a.label, annot_comments: a.comments || '' };
       }
     });
     userAnnot.set(next);
@@ -56,38 +52,38 @@
   let refPlaybackRate = 1;
 
   let label = null;
-  let comments = "";
+  let comments = '';
 
   let currReviewVideo = 0;
 
   let videoEl;
   let duration = 0;
   let clipStart = 0;
-  let clipEnd;
-  
-   onMount(() => {
-     if (!browser) return;
-     const setMeta = () => {
-       if (!videoEl) return;
-       const d = Number.isFinite(videoEl.duration) ? videoEl.duration : 0;
-       if (d > 0) {
-         duration = d;
-         if (clipEnd == null || typeof clipEnd !== 'number' || clipEnd <= 0) {
-           clipEnd = duration;
-         } else {
-           clipEnd = Math.min(clipEnd, duration);
-         }
-         if (clipStart == null) clipStart = 0;
-       }
-     };
-     if (videoEl) {
-       videoEl.addEventListener('loadedmetadata', setMeta);
-       setMeta();
-     }
-   });
-   
-   function onTimeUpdate() {
-     if (!videoEl) return;
+  let clipEnd = 0;
+
+  onMount(() => {
+    if (!browser) return;
+    const setMeta = () => {
+      if (!videoEl) return;
+      const d = Number.isFinite(videoEl.duration) ? videoEl.duration : 0;
+      if (d > 0) {
+        duration = d;
+        if (clipEnd == null || typeof clipEnd !== 'number' || clipEnd <= 0) {
+          clipEnd = duration;
+        } else {
+          clipEnd = Math.min(clipEnd, duration);
+        }
+        if (clipStart == null) clipStart = 0;
+      }
+    };
+    if (videoEl) {
+      videoEl.addEventListener('loadedmetadata', setMeta);
+      setMeta();
+    }
+  });
+
+  function onTimeUpdate() {
+    if (!videoEl) return;
     clipStart = Math.max(0, Math.min(Number(clipStart) || 0, duration || clipStart));
     clipEnd = Math.max(clipStart, Math.min(Number(clipEnd) || clipStart, duration || clipEnd));
 
@@ -99,134 +95,102 @@
         reviewVideoPaused = true;
       }
     }
-   }
-   
-   function revPlayPause() {
-    if (reviewVideoPaused) {
-      clipStart = Math.max(0, Math.min(Number(clipStart) || 0, duration || clipStart));
-      clipEnd = Math.max(clipStart, Math.min(Number(clipEnd) || clipStart, duration || clipEnd));
+  }
+
+  function revPlayPause() {
+    reviewVideoPaused = !reviewVideoPaused;
+    if (!reviewVideoPaused) {
+      clipStart = Math.max(0, Math.min(clipStart, duration));
+      clipEnd = Math.max(clipStart, Math.min(clipEnd, duration));
       if (videoEl && (videoEl.currentTime < clipStart || videoEl.currentTime > clipEnd)) {
         videoEl.currentTime = clipStart;
       }
-      reviewVideoPaused = false;
-    } else {
-      reviewVideoPaused = true;
     }
-   }
-
-  function revToggleLoop() {
-    reviewVideoLooped = !reviewVideoLooped;
   }
 
-  function revSlowDown() {
-    revPlaybackRate = Math.max(0.25, revPlaybackRate - 0.25);
-  }
+  const revToggleLoop = () => (reviewVideoLooped = !reviewVideoLooped);
+  const revSlowDown = () => (revPlaybackRate = Math.max(0.25, revPlaybackRate - 0.25));
+  const revSpeedUp = () => (revPlaybackRate = Math.min(2, revPlaybackRate + 0.25));
 
-  function revSpeedUp() {
-    revPlaybackRate = Math.min(2, revPlaybackRate + 0.25);
-  }
-
-  $: current = $userAnnot[currReviewVideo] ?? { annot_label: null, annot_comments: "" };
+  $: current = $userAnnot[currReviewVideo] ?? { annot_label: null, annot_comments: '' };
   $: label = current.annot_label ?? null;
 
   async function addAnnot(annot_label, annot_comments, annot_user) {
-    if (!annot_label || String(annot_label).trim() === "") return;
+    if (!annot_label || String(annot_label).trim() === '') return;
 
     const payload = {
       label: annot_label,
       sign: word,
       user: annot_user,
-      comments: annot_comments ?? "",
+      comments: annot_comments || '',
       time: Date.now(),
-      video_path: selectedVideoData.reviews[currReviewVideo],
+      video_path: selectedVideoData.reviews[currReviewVideo]
     };
 
     try {
       const res = await fetch(`${API_BASE}/add_annot`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
       });
-      const data = await res.json();
-      if (!res.ok) console.warn("Save failed:", data?.error || res.statusText);
-      
-      // Save last activity to localStorage for resume feature
-      if (res.ok) {
-        const lastActivity = {
-          batch: batch,
-          word: word,
-          timestamp: new Date().toISOString(),
-          video: basename(selectedVideoData.reviews[currReviewVideo])
-        };
-        localStorage.setItem(`lastActivity:${username}`, JSON.stringify(lastActivity));
+      if (!res.ok) {
+        const data = await res.json();
+        console.warn('Save failed:', data?.error || res.statusText);
+      } else {
+        localStorage.setItem(
+          `lastActivity:${username}`,
+          JSON.stringify({
+            batch,
+            word,
+            timestamp: new Date().toISOString(),
+            video: basename(selectedVideoData.reviews[currReviewVideo])
+          })
+        );
       }
     } catch (e) {
-      console.error("Save error:", e);
+      console.error('Save error:', e);
     }
   }
 
   // Handle key press events for keybinds (e.g., play/pause, approve/reject, etc.)
   function onKeyPress(event) {
-    if (event.target.tagName === "INPUT" || event.target.tagName === "TEXTAREA") {
-        return;
-    }
-    switch (event.key) {
-      case " ":
-        revPlayPause();
-        break;
-      case "-":
-        revToggleLoop ();
-        break;
-      case "0":
-        prevVideo();
-        break;
-      case "=":
-        nextVideo();
-        break;
-      case "[":
-        revSlowDown();
-        break;
-      case "]":
-        revSpeedUp();
-        break;
-      case "z":
-        setLabel("Good");
-        break;
-      case "x":
-        setLabel("Variant");
-        break;
-      case "c":
-        setLabel("Bad");
-        break;
-      case "v":
-        setLabel("Further Review");
-        break;
-      default:
-        return;
-    }
+    if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA') return;
 
-    event.preventDefault();
+    const actions = {
+      ' ': revPlayPause,
+      '-': revToggleLoop,
+      '0': prevVideo,
+      '=': nextVideo,
+      '[': revSlowDown,
+      ']': revSpeedUp,
+      z: () => setLabel('Good'),
+      x: () => setLabel('Variant'),
+      c: () => setLabel('Bad'),
+      v: () => setLabel('Further Review')
+    };
+
+    if (actions[event.key]) {
+      event.preventDefault();
+      actions[event.key]();
+    }
   }
-
 
   function setLabel(newLabel) {
     label = newLabel;
 
-      userAnnot.update(s => ({
-        ...s,
-        [currReviewVideo]: { annot_label: newLabel, annot_comments: comments ?? "" }
-      }));
+    userAnnot.update((s) => ({
+      ...s,
+      [currReviewVideo]: { annot_label: newLabel, annot_comments: comments ?? '' }
+    }));
 
-      addAnnot(newLabel, comments ?? "", username);
+    addAnnot(newLabel, comments ?? '', username);
   }
 
   function prevVideo() {
     if (currReviewVideo > 0) {
       currReviewVideo--;
       updateUrlForCurrentVideo();
-      clipStart = 0;
-      clipEnd = undefined;
-      try { videoEl?.load(); } catch (e) {}
+      resetClip();
     }
   }
 
@@ -234,295 +198,344 @@
     if (currReviewVideo < selectedVideoData.reviews.length - 1) {
       currReviewVideo++;
       updateUrlForCurrentVideo();
-      clipStart = 0;
-      clipEnd = undefined;
-      try { videoEl?.load(); } catch (e) {}
-    }  else {
-      viewSummary();
+      resetClip();
+      videoEl?.play();
+    } else {
+      goto(`/summary/${batch}/${word}`);
     }
-
-    const videoElement = document.getElementById('review-video');
-    if (videoElement) {
-        videoElement.play();
-    }
-
   }
 
-  function refPlayPause() {
-    referenceVideoPaused = !referenceVideoPaused;
+  function resetClip() {
+    clipStart = 0;
+    clipEnd = 0;
+    try {
+      videoEl?.load();
+    } catch (e) {}
   }
 
-  function refToggleLoop() {
-    referenceVideoLooped = !referenceVideoLooped;
-  }
-
-  function refSlowDown() {
-    refPlaybackRate = Math.max(0.25, refPlaybackRate - 0.25);
-  }
-
-  function refSpeedUp() {
-    refPlaybackRate = Math.min(2, refPlaybackRate + 0.25);
-  }
-
-  function toggleRefVisibility() {
-    refVisible = !refVisible;
-  }
-
-  function viewSummary() {
-    goto(`/summary/${batch}/${word}`);
-  }
+  const refPlayPause = () => (referenceVideoPaused = !referenceVideoPaused);
+  const refToggleLoop = () => (referenceVideoLooped = !referenceVideoLooped);
+  const refSlowDown = () => (refPlaybackRate = Math.max(0.25, refPlaybackRate - 0.25));
+  const refSpeedUp = () => (refPlaybackRate = Math.min(2, refPlaybackRate + 0.25));
+  const toggleRefVisibility = () => (refVisible = !refVisible);
 
   function updateUrlForCurrentVideo() {
-    const full = selectedVideoData.reviews[currReviewVideo];
-    const q = new URLSearchParams({ video: full });
-    goto(`/annotation/${batch}/${word}?${q.toString()}`, {
-      replaceState: true, keepfocus: true, noscroll: true
+    const video = selectedVideoData.reviews[currReviewVideo];
+    goto(`/annotation/${batch}/${word}?video=${video}`, {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true
     });
   }
 
   $: total = selectedVideoData?.reviews?.length ?? 0;
-  $: completed = Object.values($userAnnot)
-    .filter(v => v && typeof v.annot_label === "string" && v.annot_label.trim() !== "")
-    .length;
+  $: completed = Object.values($userAnnot).filter(
+    (v) => v && typeof v.annot_label === 'string' && v.annot_label.trim() !== ''
+  ).length;
   $: percent = total ? Math.round((completed / total) * 100) : 0;
 </script>
-
-<style>
-    .visibility-button {
-    background: rgb(0, 176, 251);
-    color: white;
-    border: none;
-    padding: 6px 12px;
-    border-radius: 6px;
-    cursor: pointer;
-  }
-
-  .visibility-button:hover {
-    background: rgb(2, 109, 155);
-  }
-</style>
-
 
 <svelte:window on:keypress={onKeyPress} />
 
 {#if selectedVideoData}
-    <div class="flex flex-col h-screen">
-      <!-- header -->
-      <div class="shrink-0 px-4 py-2 flex justify-between items-center">
-        <h1 class="text-3xl">Annotating: {word}</h1>
-        <h2 class="text-md text-center">Annotating batch: {batch}, word: {word}</h2>
-        <div>
-          <button on:click={toggleRefVisibility} class="visibility-button">
-            {refVisible ? 'Hide Reference Video' : 'Show Reference Video'}
-          </button>
-          <button on:click={viewSummary} class="visibility-button" style="margin-left: 8px;">
-            View Summary
-          </button>
-        </div>
+  <div class="flex flex-col h-screen">
+    <!-- header -->
+    <div class="shrink-0 px-4 py-2 flex justify-between items-center">
+      <h1 class="text-3xl">Annotating: {word}</h1>
+      <h2 class="text-md text-center">Annotating batch: {batch}, word: {word}</h2>
+      <div>
+        <button on:click={toggleRefVisibility} class="visibility-button">
+          {refVisible ? 'Hide Reference Video' : 'Show Reference Video'}
+        </button>
+        <button on:click={() => goto(`/summary/${batch}/${word}`)} class="visibility-button" style="margin-left: 8px;">
+          View Summary
+        </button>
       </div>
-
-      <div class="px-4 pb-2">
-        <div class="flex items-center justify-between mb-1">
-          <div class="text-sm text-gray-700">
-            {completed}/{total} • {percent}% complete
-          </div>
-          <div class="text-sm text-gray-500">
-            Video {currReviewVideo + 1} of {total}
-          </div>
-        </div>
-        <div class="w-full h-3 bg-gray-200 rounded">
-          <div
-            class="h-3 rounded bg-blue-500 transition-all"
-            style="width: {percent}%;"
-            aria-valuemin="0"
-            aria-valuemax="100"
-            aria-valuenow={percent}
-            role="progressbar"
-          />
-        </div>
-      </div>
-
-      <!-- See svelte-splitpanes https://orefalo.github.io/svelte-splitpanes/ -->
-      <div class="flex-grow overflow-hidden">
-        <Splitpanes class="h-full w-full">
-          <Pane minSize={20} maxSize={63}>
-            <!-- Video to review -->
-            <div class="flex flex-col h-full">
-              <video id="review-video" class="w-full h-full flex-1"
-                  bind:this={videoEl}
-                  src={toFlask(selectedVideoData.reviews[currReviewVideo])}
-                  loop={reviewVideoLooped}
-                  autoplay
-                  on:timeupdate={onTimeUpdate}
-                  bind:paused={reviewVideoPaused}
-                  bind:playbackRate={revPlaybackRate} />
-
-              <!-- Clip controls: numeric fields + sliders + Play button -->
-              <div class="p-2 flex flex-wrap items-center gap-2 bg-white">
-                <label class="text-sm">Start:
-                  <input type="number" min="0" step="0.1" bind:value={clipStart} class="ml-1 w-20" />
-                </label>
-                <label class="text-sm">End:
-                  <input type="number" min="0" step="0.1" bind:value={clipEnd} class="ml-1 w-20" />
-                </label>
-                <!-- Play Clip removed: playback always follows sliders -->
-                <div class="flex-1 min-w-[200px]">
-                  <input type="range" min="0" max={duration || 60} step="0.1" bind:value={clipStart} class="w-full" />
-                  <input type="range" min="0" max={duration || 60} step="0.1" bind:value={clipEnd} class="w-full mt-1" />
-                </div>
-                <div class="text-sm ml-2">Duration: {duration ? duration.toFixed(1) + 's' : '—'}</div>
-              </div>
-            </div>
-          </Pane>
-          {#if refVisible}
-            <Pane>
-              <Splitpanes horizontal={true}>
-                <Pane minSize={15} maxSize={80}>
-                  <!-- Reference video -->
-                  <video class="w-full h-full"
-                      src={toFlask(selectedVideoData.reference)}
-                      loop={referenceVideoLooped}
-                      autoplay
-                      bind:paused={referenceVideoPaused}
-                      bind:playbackRate={refPlaybackRate} />
-                </Pane>
-                <Pane>
-                  <!-- Comment panel -->
-                  <div class="w-full h-full bg-aquamarine p-0">
-                    <textarea
-                      bind:value={comments}
-                      on:blur={() => { if (label) addAnnot(label, comments ?? "", username); }}
-                      on:keydown={(e) => {
-                        if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && label) {
-                          addAnnot(label, comments ?? "", username);
-                        }
-                      }}
-                      class="w-full h-full p-10 text-left align-top resize-none outline-none bg-transparent text-black text-mn"
-                      placeholder="Add any comments here..."
-                    ></textarea>
-                  </div>
-                </Pane>
-              </Splitpanes>
-            </Pane>
-          {/if}
-        </Splitpanes>
     </div>
 
-  <!-- Video controls -->
+    <div class="px-4 pb-2">
+      <div class="flex items-center justify-between mb-1">
+        <div class="text-sm text-gray-700">
+          {completed}/{total} • {percent}% complete
+        </div>
+        <div class="text-sm text-gray-500">
+          Video {currReviewVideo + 1} of {total}
+        </div>
+      </div>
+      <div class="w-full h-3 bg-gray-200 rounded">
+        <div
+          class="h-3 rounded bg-blue-500 transition-all"
+          style="width: {percent}%;"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuenow={percent}
+          role="progressbar"
+        />
+      </div>
+    </div>
+
+    <!-- See svelte-splitpanes https://orefalo.github.io/svelte-splitpanes/ -->
+    <div class="flex-grow overflow-hidden">
+      <Splitpanes class="h-full w-full">
+        <Pane minSize={20} maxSize={63}>
+          <!-- Video to review -->
+          <div class="flex flex-col h-full overflow-hidden">
+            <div class="flex-1 overflow-hidden">
+              <video
+                id="review-video"
+                class="w-full h-full object-contain"
+                bind:this={videoEl}
+                src={toFlask(selectedVideoData.reviews[currReviewVideo])}
+                loop={reviewVideoLooped}
+                autoplay
+                on:timeupdate={onTimeUpdate}
+                bind:paused={reviewVideoPaused}
+                bind:playbackRate={revPlaybackRate}
+              />
+            </div>
+
+            <!-- Clip controls: numeric fields + sliders always visible below video -->
+            <div class="shrink-0 p-4 bg-gray-50 border-t border-gray-200">
+              <div class="flex items-center gap-3 mb-3">
+                <label class="text-sm font-medium whitespace-nowrap"
+                  >Start:
+                  <input
+                    type="number"
+                    min="0"
+                    max={duration || 10}
+                    step="0.1"
+                    bind:value={clipStart}
+                    class="ml-1 w-20 px-2 py-1 border border-gray-300 rounded"
+                  />
+                  <span class="ml-1">s</span>
+                </label>
+                <label class="text-sm font-medium whitespace-nowrap"
+                  >End:
+                  <input
+                    type="number"
+                    min="0"
+                    max={duration || 10}
+                    step="0.1"
+                    bind:value={clipEnd}
+                    class="ml-1 w-20 px-2 py-1 border border-gray-300 rounded"
+                  />
+                  <span class="ml-1">s</span>
+                </label>
+                <div class="text-sm font-medium ml-auto">
+                  Duration: {duration ? duration.toFixed(1) + 's' : '—'}
+                </div>
+              </div>
+
+              <!-- Dual-handle range slider -->
+              <div class="relative w-full" style="height: 20px; padding: 10px 0;">
+                <!-- background line -->
+                <div
+                  class="absolute w-full h-1 bg-gray-300 rounded"
+                  style="top: 50%; transform: translateY(-50%);"
+                ></div>
+
+                <!-- active range line -->
+                <div
+                  class="absolute h-1 bg-blue-500 rounded pointer-events-none"
+                  style="top: 50%; transform: translateY(-50%); 
+                  left: {(clipStart / (duration || 10)) * 100}%; 
+                  width: {((clipEnd - clipStart) / (duration || 10)) * 100}%;"
+                ></div>
+
+                <!-- End handle slider (bottom layer) -->
+                <input
+                  type="range"
+                  min="0"
+                  max={duration || 60}
+                  step="0.01"
+                  bind:value={clipEnd}
+                  class="range-slider-end"
+                  style="position: absolute; width: 100%; top: 0; z-index: 1;"
+                />
+
+                <!-- Start handle slider (top layer) -->
+                <input
+                  type="range"
+                  min="0"
+                  max={duration || 60}
+                  step="0.01"
+                  bind:value={clipStart}
+                  class="range-slider-start"
+                  style="position: absolute; width: 100%; top: 0; z-index: 2;"
+                />
+              </div>
+            </div>
+          </div>
+        </Pane>
+        {#if refVisible}
+          <Pane>
+            <Splitpanes horizontal={true}>
+              <Pane minSize={15} maxSize={80}>
+                <!-- Reference video -->
+                <video
+                  class="w-full h-full"
+                  src={toFlask(selectedVideoData.reference)}
+                  loop={referenceVideoLooped}
+                  autoplay
+                  bind:paused={referenceVideoPaused}
+                  bind:playbackRate={refPlaybackRate}
+                />
+              </Pane>
+              <Pane>
+                <!-- Comment panel -->
+                <div class="w-full h-full bg-aquamarine p-0">
+                  <textarea
+                    bind:value={comments}
+                    on:blur={() => {
+                      if (label) addAnnot(label, comments ?? '', username);
+                    }}
+                    on:keydown={(e) => {
+                      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && label) {
+                        addAnnot(label, comments ?? '', username);
+                      }
+                    }}
+                    class="w-full h-full p-10 text-left align-top resize-none outline-none bg-transparent text-black text-mn"
+                    placeholder="Add any comments here..."
+                  ></textarea>
+                </div>
+              </Pane>
+            </Splitpanes>
+          </Pane>
+        {/if}
+      </Splitpanes>
+    </div>
+
+    <!-- Video controls -->
     <div class="shrink-0 h-20 flex items-center bg-white border-t border-gray-300 z-30">
       <!-- Review Video controls -->
       <div class="w-1/3 h-20 flex items-center justify-start">
         <!-- Pause/Play button-->
         <button on:click={revPlayPause}
-            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors" 
-            tabindex="-1">
-          <img id="playPauseIcon" class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
-              src="{reviewVideoPaused ? "/play" : "/pause"}.svg"
+          class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
+          tabindex="-1">
+          <img id="playPauseIcon"
+              class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
+              src="{reviewVideoPaused ? '/play' : '/pause'}.svg"
               alt="paused icon">
         </button>
 
         <button on:click={revToggleLoop}
-            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
-            tabindex="-1">
-          <img id="loopIcon" class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
-              src="{reviewVideoLooped ? "/loop" : "/not-looped" }.svg"
+          class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
+          tabindex="-1">
+          <img id="loopIcon"
+              class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
+              src="{reviewVideoLooped ? '/loop' : '/not-looped'}.svg"
               alt="play icon">
         </button>
 
         <div class="join m-3">
-            <!-- Slow down video button-->
-            <button on:click={revSlowDown}
-              class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white p-2 md:p-2 lg:p-2.5 xl:p-3 rounded-md join-item transition-colors"
-              tabindex="-1">
-              <img class="w-8 h-8 md:w-7.5 md:h-7.5 lg:w-8 lg:h-8 xl:w-9 xl:h-9" src="/slow-down-dark.svg" alt="turtle icon to indicate slow down">
-            </button>
+          <!-- Slow down video button-->
+          <button on:click={revSlowDown}
+            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white p-2 md:p-2 lg:p-2.5 xl:p-3 rounded-md join-item transition-colors"
+            tabindex="-1">
+            <img class="w-8 h-8 md:w-7.5 md:h-7.5 lg:w-8 lg:h-8 xl:w-9 xl:h-9"
+                src="/slow-down-dark.svg"
+                alt="turtle icon to indicate slow down">
+          </button>
 
-            <!-- Playback rate reporter -->
-            <div class="bg-[#D9D9D9] flex text-black w-20 rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors">
-              <div class="flex items-center m-auto">{revPlaybackRate.toFixed(2)}&times;</div>
-            </div>
+          <!-- Playback rate reporter -->
+          <div
+            class="bg-[#D9D9D9] flex text-black w-20 rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors"
+          >
+            <div class="flex items-center m-auto">{revPlaybackRate.toFixed(2)}&times;</div>
+          </div>
 
-            <!-- Speed up video button-->
-            <button on:click={revSpeedUp} 
-              class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md  p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors"
-              tabindex="-1">
-              <img class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8" src="/speed-up-dark.svg" alt="bunny icon to indicate speed up">
-            </button>
+          <!-- Speed up video button-->
+          <button on:click={revSpeedUp}
+            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors"
+            tabindex="-1">
+            <img class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
+                src="/speed-up-dark.svg"
+                alt="bunny icon to indicate speed up">
+          </button>
         </div>
 
         <!-- Previous video -->
         <div class="join m-3">
-            <button on:click={prevVideo}
-              class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors"
-              tabindex="-1">
-              <img class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8" src="/previous.svg" alt="previous video icon">
-            </button>
+          <button on:click={prevVideo}
+            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors"
+            tabindex="-1">
+            <img class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
+                src="/previous.svg"
+                alt="previous video icon">
+          </button>
 
-            <!-- Next video -->
-            <button on:click={nextVideo}
-              class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors"
-              tabindex="-1">
-              <img class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8" src="/next.svg" alt="next video icon">
-            </button>
-            
+          <!-- Next video -->
+          <button on:click={nextVideo}
+            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors"
+            tabindex="-1">
+            <img class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
+                src="/next.svg"
+                alt="next video icon">
+          </button>
         </div>
       </div>
 
       <!-- Annotation labeling -->
       <div class="w-1/3 h-20 flex items-center justify-start">
         <!-- Good button -->
-        <button on:click={() => setLabel("Good")}
-            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
-            tabindex="-1">
-          <img id="good-button" class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
+        <button on:click={() => setLabel('Good')}
+          class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
+          tabindex="-1">
+          <img id="good-button"
+              class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
               src="/thumbs-up.svg"
               alt="thumbs up icon">
         </button>
 
         <!-- Variant button -->
-        <button on:click={() => setLabel("Variant")}
-            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
-            tabindex="-1">
-          <img id="variant-button" class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
+        <button on:click={() => setLabel('Variant')}
+          class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
+          tabindex="-1">
+          <img id="variant-button"
+              class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
               src="/variant.svg"
               alt="icon">
         </button>
 
         <!-- Bad button -->
-        <button on:click={() => setLabel("Bad")}
-            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
-            tabindex="-1">
-          <img id="bad-button" class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
+        <button on:click={() => setLabel('Bad')}
+          class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
+          tabindex="-1">
+          <img id="bad-button"
+              class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
               src="/thumbs-down.svg"
               alt="thumbs down icon">
         </button>
 
         <!-- Further Review button -->
-        <button on:click={() => setLabel("Further Review")}
-            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
-            tabindex="-1">
-          <img id="further-review-button" class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
+        <button on:click={() => setLabel('Further Review')}
+          class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
+          tabindex="-1">
+          <img id="further-review-button" 
+              class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
               src="/archive.svg"
               alt="archive icon">
         </button>
 
         <!-- Label -->
         <div class="flex w-100px ml-3 min-w-[3rem] md:min-w-[6rem] lg:min-w-[8rem] h-20">
-          <div 
+          <div
             class="flex items-center gap-2 p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 rounded-md transition-colors whitespace-nowrap"
-            class:bg-green-200={label === "Good"}
-            class:bg-yellow-200={label === "Variant"}
-            class:bg-red-200={label === "Bad"}
-            class:bg-blue-200={label === "Further Review"}
-            class:bg-[#D9D9D9]={!label}>
+            class:bg-green-200={label === 'Good'}
+            class:bg-yellow-200={label === 'Variant'}
+            class:bg-red-200={label === 'Bad'}
+            class:bg-blue-200={label === 'Further Review'}
+            class:bg-[#D9D9D9]={!label}
+          >
             {#if label}
-              {#if label === "Good"}
+              {#if label === 'Good'}
                 <img src="/thumbs-up.svg" class="w-6 h-6" alt="thumbs up icon" />
-              {:else if label === "Variant"}
+              {:else if label === 'Variant'}
                 <img src="/variant.svg" class="w-6 h-6" alt="variant icon" />
-              {:else if label === "Bad"}
+              {:else if label === 'Bad'}
                 <img src="/thumbs-down.svg" class="w-6 h-6" alt="thumbs down icon" />
-              {:else if label === "Further Review"}
+              {:else if label === 'Further Review'}
                 <img src="/archive.svg" class="w-6 h-6" alt="archive icon" />
               {/if}
               <p class="text-sm md:text-md lg:text-lg">{label}</p>
@@ -537,40 +550,44 @@
       <div class="w-1/3 h-20 flex items-center justify-end">
         <!-- Pause/Play button-->
         <button on:click={refPlayPause}
-            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
-            tabindex="-1">
-          <img id="playPauseIcon" class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
-              src="{referenceVideoPaused ? "/play" : "/pause"}.svg"
+          class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
+          tabindex="-1">
+          <img id="playPauseIcon" class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8" 
+              src="{referenceVideoPaused ? '/play' : '/pause'}.svg" 
               alt="paused icon">
         </button>
 
         <button on:click={refToggleLoop}
-            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
-            tabindex="-1">
-          <img id="loopIcon" class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8"
-              src="{referenceVideoLooped ? "/loop" : "/not-looped" }.svg"
+          class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 m-3 transition-colors"
+          tabindex="-1">
+          <img id="loopIcon" class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8" 
+              src="{referenceVideoLooped ? '/loop' : '/not-looped'}.svg" 
               alt="play icon">
         </button>
 
         <div class="join m-3">
-            <!-- Slow down video button-->
-            <button on:click={refSlowDown} 
-              class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white p-2 md:p-2 lg:p-2.5 xl:p-3 rounded-md join-item transition-colors"
-              tabindex="-1">
-              <img class="w-8 h-8 md:w-7.5 md:h-7.5 lg:w-8 lg:h-8 xl:w-9 xl:h-9" src="/slow-down-dark.svg" alt="turtle icon to indicate slow down">
-            </button>
+          <!-- Slow down video button-->
+          <button on:click={refSlowDown} 
+            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white p-2 md:p-2 lg:p-2.5 xl:p-3 rounded-md join-item transition-colors" 
+            tabindex="-1">
+            <img class="w-8 h-8 md:w-7.5 md:h-7.5 lg:w-8 lg:h-8 xl:w-9 xl:h-9" 
+                src="/slow-down-dark.svg" 
+                alt="turtle icon to indicate slow down">
+          </button>
 
-            <!-- Playback rate reporter -->
-            <div class="bg-[#D9D9D9] flex text-black w-20 rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors">
-              <div class="flex items-center m-auto">{refPlaybackRate.toFixed(2)}&times;</div>
-            </div>
+          <!-- Playback rate reporter -->
+          <div class="bg-[#D9D9D9] flex text-black w-20 rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors">
+            <div class="flex items-center m-auto">{refPlaybackRate.toFixed(2)}&times;</div>
+          </div>
 
-            <!-- Speed up video button-->
-            <button on:click={refSpeedUp}
-              class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md  p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors"
-              tabindex="-1">
-              <img class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8" src="/speed-up-dark.svg" alt="bunny icon to indicate speed up">
-            </button>
+          <!-- Speed up video button-->
+          <button on:click={refSpeedUp}
+            class="bg-[#D9D9D9] hover:bg-[#A9A9A9] text-white rounded-md p-2 md:p-2 lg:p-2.5 xl:p-3 join-item transition-colors"
+            tabindex="-1">
+            <img class="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 xl:w-8 xl:h-8" 
+                src="/speed-up-dark.svg" 
+                alt="bunny icon to indicate speed up">
+          </button>
         </div>
       </div>
     </div>
@@ -578,3 +595,98 @@
 {:else}
   <p>No video data available for the word "{word}".</p>
 {/if}
+
+<style>
+  .visibility-button {
+    background: #3b82f6;
+    color: white;
+    border: none;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+
+  .visibility-button:hover {
+    background: #2563eb;
+  }
+
+  /* Custom range slider styling */
+  .range-slider-start,
+  .range-slider-end {
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent;
+    outline: none;
+    height: 20px;
+    margin: 0;
+    padding: 0;
+    pointer-events: none;
+  }
+
+  /* Webkit (Chrome, Safari) track styling - make invisible */
+  .range-slider-start::-webkit-slider-runnable-track,
+  .range-slider-end::-webkit-slider-runnable-track {
+    background: transparent;
+    height: 0;
+    border: none;
+  }
+
+  /* Webkit (Chrome, Safari) thumb styling */
+  .range-slider-start::-webkit-slider-thumb,
+  .range-slider-end::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #3b82f6;
+    cursor: grab;
+    border: 3px solid white;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    margin-top: -10px;
+    pointer-events: auto;
+  }
+
+  .range-slider-start::-webkit-slider-thumb:hover,
+  .range-slider-end::-webkit-slider-thumb:hover {
+    background: #2563eb;
+  }
+
+  .range-slider-start::-webkit-slider-thumb:active,
+  .range-slider-end::-webkit-slider-thumb:active {
+    background: #1d4ed8;
+    cursor: grabbing;
+  }
+
+  /* Firefox track styling - make invisible */
+  .range-slider-start::-moz-range-track,
+  .range-slider-end::-moz-range-track {
+    background: transparent;
+    height: 0;
+    border: none;
+  }
+
+  /* Firefox thumb styling */
+  .range-slider-start::-moz-range-thumb,
+  .range-slider-end::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #3b82f6;
+    cursor: grab;
+    border: 3px solid white;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    pointer-events: auto;
+  }
+
+  .range-slider-start::-moz-range-thumb:hover,
+  .range-slider-end::-moz-range-thumb:hover {
+    background: #2563eb;
+  }
+
+  .range-slider-start::-moz-range-thumb:active,
+  .range-slider-end::-moz-range-thumb:active {
+    background: #1d4ed8;
+    cursor: grabbing;
+  }
+</style>

--- a/WebAnnotationEngine/src/routes/annotation/[batch]/[word]/+page.svelte
+++ b/WebAnnotationEngine/src/routes/annotation/[batch]/[word]/+page.svelte
@@ -1,6 +1,6 @@
 <script>
-  // Accessing the `data` prop containing word and selectedVideoData from `+page.js`
   export let data;
+  import { browser } from '$app/environment';
   import { onMount } from 'svelte';
   import { Pane, Splitpanes } from 'svelte-splitpanes';
   import {writable} from "svelte/store";
@@ -10,7 +10,6 @@
   export const userAnnot = writable({})
 
   const { batch, word, selectedVideoData } = data;
-
   const API_BASE = "http://127.0.0.1:5000";
   const basename = (p) => (p || "").split("/").pop();
   const username = (localStorage.getItem("username") || "").trim();
@@ -24,14 +23,8 @@
 
     const url = $page.url; // SvelteKit store value
     const qVideo = url.searchParams.get('video');
-    const qIdx   = url.searchParams.get('idx');
 
-    if (qIdx !== null) {
-      const i = Number(qIdx);
-      if (!Number.isNaN(i) && i >= 0 && i < (selectedVideoData?.reviews?.length ?? 0)) {
-        currReviewVideo = i;
-      }
-    } else if (qVideo) {
+    if (qVideo) {
       const i = selectedVideoData.reviews.findIndex(p =>
         p === qVideo || basename(p) === basename(qVideo)
       );
@@ -51,35 +44,75 @@
       }
     });
     userAnnot.set(next);
-
-    // Pre-fill current video’s fields if present
-    const cur = saved[basename(selectedVideoData.reviews[currReviewVideo])];
-    if (cur) {
-      label = cur.label;
-      comments = cur.comments || "";
-    }
   });
 
   let reviewVideoPaused = true;
   let reviewVideoLooped = true;
   let revPlaybackRate = 1;
+  let refVisible = true;
 
   let referenceVideoPaused = true;
   let referenceVideoLooped = true;
   let refPlaybackRate = 1;
 
-  // @ts-ignore 
   let label = null;
-
   let comments = "";
 
   let currReviewVideo = 0;
 
-  let refVisible = true;
+  let videoEl;
+  let duration = 0;
+  let clipStart = 0;
+  let clipEnd;
+  
+   onMount(() => {
+     if (!browser) return;
+     const setMeta = () => {
+       if (!videoEl) return;
+       const d = Number.isFinite(videoEl.duration) ? videoEl.duration : 0;
+       if (d > 0) {
+         duration = d;
+         if (clipEnd == null || typeof clipEnd !== 'number' || clipEnd <= 0) {
+           clipEnd = duration;
+         } else {
+           clipEnd = Math.min(clipEnd, duration);
+         }
+         if (clipStart == null) clipStart = 0;
+       }
+     };
+     if (videoEl) {
+       videoEl.addEventListener('loadedmetadata', setMeta);
+       setMeta();
+     }
+   });
+   
+   function onTimeUpdate() {
+     if (!videoEl) return;
+    clipStart = Math.max(0, Math.min(Number(clipStart) || 0, duration || clipStart));
+    clipEnd = Math.max(clipStart, Math.min(Number(clipEnd) || clipStart, duration || clipEnd));
 
-  function revPlayPause() {
-    reviewVideoPaused = !reviewVideoPaused;
-  }
+    if (videoEl.currentTime >= clipEnd - 0.05) {
+      if (reviewVideoLooped) {
+        videoEl.currentTime = clipStart;
+      } else {
+        videoEl.pause();
+        reviewVideoPaused = true;
+      }
+    }
+   }
+   
+   function revPlayPause() {
+    if (reviewVideoPaused) {
+      clipStart = Math.max(0, Math.min(Number(clipStart) || 0, duration || clipStart));
+      clipEnd = Math.max(clipStart, Math.min(Number(clipEnd) || clipStart, duration || clipEnd));
+      if (videoEl && (videoEl.currentTime < clipStart || videoEl.currentTime > clipEnd)) {
+        videoEl.currentTime = clipStart;
+      }
+      reviewVideoPaused = false;
+    } else {
+      reviewVideoPaused = true;
+    }
+   }
 
   function revToggleLoop() {
     reviewVideoLooped = !reviewVideoLooped;
@@ -191,30 +224,22 @@
     if (currReviewVideo > 0) {
       currReviewVideo--;
       updateUrlForCurrentVideo();
+      clipStart = 0;
+      clipEnd = undefined;
+      try { videoEl?.load(); } catch (e) {}
     }
-  }
-
-  function resetState(){
-    // reviewVideoPaused = true;
-    // referenceVideoPaused = true;
-
-    label = null;
-    comments = "";
   }
 
   function nextVideo() {
     if (currReviewVideo < selectedVideoData.reviews.length - 1) {
       currReviewVideo++;
       updateUrlForCurrentVideo();
-      const videoElement = document.getElementById('review-video');
-      if (videoElement) {
-          videoElement.play();
-      }
+      clipStart = 0;
+      clipEnd = undefined;
+      try { videoEl?.load(); } catch (e) {}
     }  else {
       viewSummary();
     }
-
-    resetState();
 
     const videoElement = document.getElementById('review-video');
     if (videoElement) {
@@ -322,12 +347,32 @@
         <Splitpanes class="h-full w-full">
           <Pane minSize={20} maxSize={63}>
             <!-- Video to review -->
-            <video id="review-video" class="w-full h-full" 
-                src={toFlask(selectedVideoData.reviews[currReviewVideo])}
-                loop={reviewVideoLooped}   
-                autoplay
-                bind:paused={reviewVideoPaused}
-                bind:playbackRate={revPlaybackRate} />
+            <div class="flex flex-col h-full">
+              <video id="review-video" class="w-full h-full flex-1"
+                  bind:this={videoEl}
+                  src={toFlask(selectedVideoData.reviews[currReviewVideo])}
+                  loop={reviewVideoLooped}
+                  autoplay
+                  on:timeupdate={onTimeUpdate}
+                  bind:paused={reviewVideoPaused}
+                  bind:playbackRate={revPlaybackRate} />
+
+              <!-- Clip controls: numeric fields + sliders + Play button -->
+              <div class="p-2 flex flex-wrap items-center gap-2 bg-white">
+                <label class="text-sm">Start:
+                  <input type="number" min="0" step="0.1" bind:value={clipStart} class="ml-1 w-20" />
+                </label>
+                <label class="text-sm">End:
+                  <input type="number" min="0" step="0.1" bind:value={clipEnd} class="ml-1 w-20" />
+                </label>
+                <!-- Play Clip removed: playback always follows sliders -->
+                <div class="flex-1 min-w-[200px]">
+                  <input type="range" min="0" max={duration || 60} step="0.1" bind:value={clipStart} class="w-full" />
+                  <input type="range" min="0" max={duration || 60} step="0.1" bind:value={clipEnd} class="w-full mt-1" />
+                </div>
+                <div class="text-sm ml-2">Duration: {duration ? duration.toFixed(1) + 's' : '—'}</div>
+              </div>
+            </div>
           </Pane>
           {#if refVisible}
             <Pane>

--- a/WebAnnotationEngine/src/routes/summary/[batch]/[word]/+page.svelte
+++ b/WebAnnotationEngine/src/routes/summary/[batch]/[word]/+page.svelte
@@ -1,75 +1,72 @@
 <script>
-    import { onMount } from 'svelte';
-    import { page } from '$app/stores';
-    import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
 
-    const API_BASE = 'http://127.0.0.1:5000';
-    const username = (localStorage.getItem('username') || '').trim();
+  const API_BASE = 'http://127.0.0.1:5000';
+  const username = (localStorage.getItem('username') || '').trim();
+  const basename = (p) => (p || '').split('/').pop();
 
-    let items = [];
-    let loading = true;
-    let error = null;
+  let items = [];
+  let loading = true;
+  let error = null;
 
-    $: params = $page.params;
+  $: params = $page.params;
 
-    function basename(p) {
-        return (p || '').split('/').pop();
+  onMount(async () => {
+    try {
+      const annUrl = new URL(`${API_BASE}/annots`);
+      annUrl.searchParams.set('user', username);
+      annUrl.searchParams.set('sign', params.word);
+      const annRes = await fetch(annUrl);
+      if (!annRes.ok) throw new Error(`HTTP ${annRes.status} (annots)`);
+      const saved = await annRes.json();
+
+      const batchesRes = await fetch(`${API_BASE}/api/batches`);
+      if (!batchesRes.ok) throw new Error(`HTTP ${batchesRes.status}`);
+      const batches = await batchesRes.json();
+
+      const entry = batches?.[params.batch]?.[params.word];
+      const reviews = entry?.reviews || [];
+
+      items = reviews.map((full) => {
+        const base = basename(full);
+        const a = saved[base];
+        return {
+          full,
+          video: base,
+          label: a && a.label && String(a.label).trim() ? a.label : 'Unlabeled',
+          time: a?.time ?? null
+        };
+      });
+    } catch (e) {
+      error = String(e);
+    } finally {
+      loading = false;
     }
+  });
 
-    onMount(async () => {
-        try {
-            const annUrl = new URL(`${API_BASE}/annots`);
-            annUrl.searchParams.set('user', username);
-            annUrl.searchParams.set('sign', params.word);
-            const annRes = await fetch(annUrl);
-            if (!annRes.ok) throw new Error(`HTTP ${annRes.status} (annots)`);
-            const saved = await annRes.json(); 
+  function review(item) {
+    const q = new URLSearchParams({ video: item.full });
+    goto(`/annotation/${params.batch}/${params.word}?${q.toString()}`);
+  }
 
-            const batchesRes = await fetch(`${API_BASE}/api/batches`);
-            if (!batchesRes.ok) throw new Error(`HTTP ${batchesRes.status} (batches)`);
-            const batches = await batchesRes.json();
-
-            const entry = batches?.[params.batch]?.[params.word];
-            const reviews = entry?.reviews || [];
-
-            items = reviews.map(full => {
-                const base = basename(full);
-                const a = saved[base];
-                return {
-                    full,
-                    video: base,
-                    label: (a && a.label && String(a.label).trim()) ? a.label : 'Unlabeled',
-                    time: a?.time ?? null
-                };
-            });
-
-        } catch (e) {
-            error = String(e);
-        } finally {
-            loading = false;
-        }
-    });
-
-    function review(item) {
-        const q = new URLSearchParams({ video: item.full });
-        goto(`/annotation/${params.batch}/${params.word}?${q.toString()}`);
-    }
-
-    function labelMeta(l) {
-        const base = "inline-flex items-center gap-2 px-2.5 py-1 rounded-md text-sm font-medium shrink-0";
-        if (l === "Good")           return { cls: `${base} bg-green-200`,  icon: "/thumbs-up.svg" };
-        if (l === "Variant")        return { cls: `${base} bg-yellow-200`, icon: "/variant.svg" };
-        if (l === "Bad")            return { cls: `${base} bg-red-200`,    icon: "/thumbs-down.svg" };
-        if (l === "Further Review") return { cls: `${base} bg-blue-200`,   icon: "/archive.svg" };
-        if (l === "Unlabeled")      return { cls: `${base} bg-gray-200`,   icon: "" };   // NEW
-        return { cls: `${base} bg-gray-200`, icon: "" };
-    }
+  function labelMeta(l) {
+    const base =
+      'inline-flex items-center gap-2 px-2.5 py-1 rounded-md text-sm font-medium shrink-0';
+    if (l === 'Good') return { cls: `${base} bg-green-200`, icon: '/thumbs-up.svg' };
+    if (l === 'Variant') return { cls: `${base} bg-yellow-200`, icon: '/variant.svg' };
+    if (l === 'Bad') return { cls: `${base} bg-red-200`, icon: '/thumbs-down.svg' };
+    if (l === 'Further Review') return { cls: `${base} bg-blue-200`, icon: '/archive.svg' };
+    if (l === 'Unlabeled') return { cls: `${base} bg-gray-200`, icon: '' }; // NEW
+    return { cls: `${base} bg-gray-200`, icon: '' };
+  }
 </script>
 
 {#if loading}
   <div class="p-6 text-gray-500">Loading…</div>
 {:else if error}
-    <div class="p-6 text-red-600">Error: {error}</div>
+  <div class="p-6 text-red-600">Error: {error}</div>
 {:else}
   <div class="p-6 max-w-3xl mx-auto">
     <h1 class="text-xl font-semibold">Summary — {params.word} <span class="text-gray-500">({params.batch})</span></h1>
@@ -78,25 +75,20 @@
     {:else}
       <div class="mt-4 border rounded overflow-hidden">
         {#each items as it (it.full)}
-        {@const meta = labelMeta(it.label)} 
+          {@const meta = labelMeta(it.label)}
 
-        <div class="flex items-center gap-3 px-3 py-2 border-b last:border-b-0">
-            <div class="min-w-0 flex-1">
-            <span class="font-mono truncate block" title={it.full}>{it.video}</span>
-            </div>
-
-            <span class={meta.cls}>
-            {#if meta.icon}<img src={meta.icon} class="w-4 h-4" alt="" />{/if}
-            {it.label}
+          <div class="flex items-center gap-3 px-3 py-2 border-b last:border-b-0">
+            <span class="font-mono truncate flex-1" title={it.full}>{it.video}</span>
+            <span class="inline-flex items-center gap-2 px-2.5 py-1 rounded-md text-sm font-medium {meta.cls}">
+              {#if meta.icon}<img src={meta.icon} class="w-4 h-4" alt="" />{/if}
+              {it.label}
             </span>
-
-            <button class="shrink-0 px-3 py-1 rounded bg-blue-600 text-white hover:bg-blue-700"
+            <button class="px-3 py-1 rounded bg-blue-600 text-white hover:bg-blue-700"
                     on:click={() => review(it)}>
-            Review
+              Review
             </button>
-        </div>
+          </div>
         {/each}
-
       </div>
     {/if}
   </div>

--- a/flask_app/batches.py
+++ b/flask_app/batches.py
@@ -5,7 +5,6 @@ from flask import Blueprint, jsonify, current_app
 batches_bp = Blueprint("batches", __name__)
 
 def _load_config():
-    """Load the video configuration file."""
     repo_root = os.path.abspath(os.path.join(current_app.root_path, ".."))
     web_root = os.path.join(repo_root, "WebAnnotationEngine")
     cfg_path = os.path.join(web_root, "src", "routes", "config", "videoConfig.json")
@@ -24,18 +23,12 @@ def _load_config():
 
 @batches_bp.get("/")
 def get_batches():
-    """
-    GET endpoint that returns batch configuration with video paths.
-    Equivalent to the Svelte GET function in +server.js
-    """
     try:
         config, sign_list_data, web_root = _load_config()
-        
-        # Resolve paths
+
         review_source = config["review_source"]
         if not os.path.isabs(review_source):
             review_source = os.path.join(web_root, review_source)
-        
         reference_source = config["reference_source"]
         if not os.path.isabs(reference_source):
             reference_source = os.path.join(web_root, reference_source)
@@ -45,96 +38,52 @@ def get_batches():
         batches_to_load = config.get("batches", [])
         batches = {}
         
-        # Parse sign list
         sign_list_by_line = [line.strip() for line in sign_list_data.split("\n") if line.strip()]
         
-        # Determine which batches to load
         if batches_to_load:
-            # Only load specified batches
             batch_dirs = [{"name": batch} for batch in batches_to_load]
         else:
-            # Load all batches from directory
             if os.path.exists(review_source):
-                batch_dirs = [
-                    {"name": entry.name}
-                    for entry in os.scandir(review_source)
-                    if entry.is_dir()
-                ]
+                batch_dirs = [{"name": entry.name} for entry in os.scandir(review_source) if entry.is_dir()]
             else:
                 batch_dirs = []
         
-        # Process each batch
         for batch_dir in batch_dirs:
             batch_name = batch_dir["name"]
             batch_path = os.path.join(review_source, batch_name)
-            
             if not os.path.exists(batch_path):
                 continue
             
             batches[batch_name] = {}
             
-            # Get all sign directories in this batch
-            sign_dirs = [
-                entry
-                for entry in os.scandir(batch_path)
-                if entry.is_dir()
-            ]
-            
-            # Process each sign
+            sign_dirs = [entry for entry in os.scandir(batch_path) if entry.is_dir()]
             for sign_dir in sign_dirs:
                 sign_name = sign_dir.name
-                
-                # Skip if sign list is specified and this sign is not in it
                 if sign_list_data.strip() and sign_name not in sign_list_by_line:
                     continue
+                if sign_name not in batches[batch_name]:
+                    batches[batch_name][sign_name] = {"reference": None, "reviews": []}
                 
                 sign_path = sign_dir.path
-                
-                # Get all MP4 videos in this sign directory
-                videos = [
-                    file
-                    for file in os.listdir(sign_path)
-                    if file.endswith('.mp4')
-                ]
-                
-                if sign_name not in batches[batch_name]:
-                    batches[batch_name][sign_name] = {
-                        "reference": None,
-                        "reviews": []
-                    }
-                
-                # Add all review videos
+                videos = [file for file in os.listdir(sign_path) if file.endswith('.mp4')]
                 for video_file in videos:
                     file_path = os.path.join(review_api, batch_name, sign_name, video_file)
                     batches[batch_name][sign_name]["reviews"].append(file_path)
-            
-            # Remove batch if it has no signs
             if not batches[batch_name]:
                 del batches[batch_name]
         
-        # Process reference videos
         if os.path.exists(reference_source):
-            reference_files = [
-                file
-                for file in os.listdir(reference_source)
-                if file.endswith('.mp4')
-            ]
-            
+            reference_files = [file for file in os.listdir(reference_source) if file.endswith('.mp4')]
             for file in reference_files:
-                # Get sign name from filename (without extension)
                 sign_name = os.path.splitext(file)[0]
-                
-                # Skip if sign list is specified and this sign is not in it
                 if sign_list_data.strip() and sign_name not in sign_list_by_line:
                     continue
                 
                 api_path = os.path.join(reference_api, file)
-                
-                # Add reference to all batches that have this sign
                 for batch_name in batches:
                     if sign_name in batches[batch_name]:
                         batches[batch_name][sign_name]["reference"] = api_path
-        
+
         return jsonify(batches), 200
         
     except Exception as error:


### PR DESCRIPTION
Summary:
I added dual-handle trim controls (start & end) to the Review Video on the Annotation page so annotators can quickly adjust the visible portion of a clip when a sign was cut early/late. Playback will only stay within the [start, end] window. I also cleaned up Svelte code across +layout.svelte, +page.svelte, annotation +page.svelte, and summary +page.svelte.

How To Test:
For the backend, run `python3 app.py` from `flask_app`. For the frontend, run `npm run dev` from `WebAnnotationEngine`.  Navigate to an annotation page. There should be a dual-handle video trimming slider under where the review video is displayed. Drag the start and end circular handles on the slider or type into the number inputs. The video will loop only between start and end. 

Expected Results:
<img width="560" height="74" alt="image" src="https://github.com/user-attachments/assets/93d65049-7cee-4fb4-9f07-e77c08bb66d9" />
There should now be a dual-handle slider at the bottom of the review video. Start and end handles drag independently on a single track. As you move the handles, the blue segment and the numeric start/end updates live. 

Design Decisions:
The dual-handle slider allows for quick and easy video trimming. This will be helpful when we receive longer video files later.