### PR TITLE
Save clip start/end timestamps in annots table

### DIFF
--- a/WebAnnotationEngine/src/routes/+page.svelte
+++ b/WebAnnotationEngine/src/routes/+page.svelte
@@ -11,7 +11,7 @@
   let words = [];
   let selectedBatch = null;
 
-  const API_BASE = 'http://127.0.0.1:5000';
+  const API_BASE = 'http://localhost:5000';
   const basename = (p) => (p || '').split('/').pop();
 
   let wordProgress = {};

--- a/WebAnnotationEngine/src/routes/annotation/[batch]/[word]/+page.svelte
+++ b/WebAnnotationEngine/src/routes/annotation/[batch]/[word]/+page.svelte
@@ -10,7 +10,7 @@
   export const userAnnot = writable({});
 
   const { batch, word, selectedVideoData } = data;
-  const API_BASE = 'http://127.0.0.1:5000';
+  const API_BASE = 'http://localhost:5000';
   const basename = (p) => (p || '').split('/').pop();
   const username = (localStorage.getItem('username') || '').trim();
   const toFlask = (p) => {
@@ -52,9 +52,11 @@
   let refPlaybackRate = 1;
 
   let label = null;
+  
   let comments = '';
 
   let currReviewVideo = 0;
+  let lastIndex = -1;
 
   let videoEl;
   let duration = 0;
@@ -114,17 +116,23 @@
 
   $: current = $userAnnot[currReviewVideo] ?? { annot_label: null, annot_comments: '' };
   $: label = current.annot_label ?? null;
+  $: if (lastIndex !== currReviewVideo) {
+    comments = ($userAnnot[currReviewVideo]?.annot_comments) ?? '';
+    lastIndex = currReviewVideo;
+  }
 
-  async function addAnnot(annot_label, annot_comments, annot_user) {
-    if (!annot_label || String(annot_label).trim() === '') return;
+  async function addAnnot(label, comments, user, videoPath, startMs, endMs) {
+    if (!label || String(label).trim() === '') return;
 
     const payload = {
-      label: annot_label,
+      label,
       sign: word,
-      user: annot_user,
-      comments: annot_comments || '',
+      user,
+      comments,
       time: Date.now(),
-      video_path: selectedVideoData.reviews[currReviewVideo]
+      video_path: videoPath,
+      timestamp_left_ms: startMs,
+      timestamp_right_ms: endMs
     };
 
     try {
@@ -183,7 +191,10 @@
       [currReviewVideo]: { annot_label: newLabel, annot_comments: comments ?? '' }
     }));
 
-    addAnnot(newLabel, comments ?? '', username);
+   const vp = selectedVideoData.reviews[currReviewVideo];
+   const startMs = Math.round((Number(clipStart) || 0) * 1000);
+   const endMs   = Math.round((Number(clipEnd)   || 0) * 1000);
+   addAnnot(newLabel, comments ?? '', username, vp, startMs, endMs);
   }
 
   function prevVideo() {
@@ -194,13 +205,25 @@
     }
   }
 
-  function nextVideo() {
+  async function nextVideo() {
+    const currentVideoPath = selectedVideoData.reviews[currReviewVideo];
+    const currentLabel = userAnnot[currReviewVideo]?.annot_label ?? null;
+    const currentComments = userAnnot[currReviewVideo]?.annot_comments ?? '';
+    const currentStart = Math.round((Number(clipStart) || 0) * 1000);
+    const currentEnd = Math.round((Number(clipEnd) || 0) * 1000);
+
+    // save using frozen values
+    if (currentLabel) {
+      await addAnnot(currentLabel, currentComments, username, currentVideoPath, currentStart, currentEnd);
+    }
+
     if (currReviewVideo < selectedVideoData.reviews.length - 1) {
       currReviewVideo++;
       updateUrlForCurrentVideo();
       resetClip();
       videoEl?.play();
     } else {
+      // if we're at the last one, go to summary
       goto(`/summary/${batch}/${word}`);
     }
   }
@@ -387,11 +410,19 @@
                   <textarea
                     bind:value={comments}
                     on:blur={() => {
-                      if (label) addAnnot(label, comments ?? '', username);
+                      if (label) {
+                        const vp = selectedVideoData.reviews[currReviewVideo];
+                        const startMs = Math.round((Number(clipStart) || 0) * 1000);
+                        const endMs   = Math.round((Number(clipEnd)   || 0) * 1000);
+                        addAnnot(label, comments ?? '', username, vp, startMs, endMs);
+                      }
                     }}
                     on:keydown={(e) => {
                       if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && label) {
-                        addAnnot(label, comments ?? '', username);
+                        const vp = selectedVideoData.reviews[currReviewVideo];
+                        const startMs = Math.round((Number(clipStart) || 0) * 1000);
+                        const endMs   = Math.round((Number(clipEnd)   || 0) * 1000);
+                        addAnnot(label, comments ?? '', username, vp, startMs, endMs);
                       }
                     }}
                     class="w-full h-full p-10 text-left align-top resize-none outline-none bg-transparent text-black text-mn"

--- a/WebAnnotationEngine/src/routes/summary/[batch]/[word]/+page.svelte
+++ b/WebAnnotationEngine/src/routes/summary/[batch]/[word]/+page.svelte
@@ -3,7 +3,7 @@
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
 
-  const API_BASE = 'http://127.0.0.1:5000';
+  const API_BASE = 'http://localhost:5000';
   const username = (localStorage.getItem('username') || '').trim();
   const basename = (p) => (p || '').split('/').pop();
 

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -6,6 +6,7 @@ from config import Config, DBLogin
 from datetime import datetime
 from sqlalchemy.dialects.mysql import insert
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy import inspect, text
 from videos import videos_bp
 from batches import batches_bp
 from models import Annot
@@ -20,9 +21,20 @@ app.register_blueprint(batches_bp, url_prefix="/api/batches")
 
 db.init_app(app)
 
+def ensure_schema():
+    # add timestamp columns to annots table if they don't exist
+    inspector = inspect(db.engine)
+    columns = [col["name"] for col in inspector.get_columns("annots")]
+
+    with db.engine.begin() as conn:
+        if "timestamp_left_ms" not in columns:
+            conn.execute(text("ALTER TABLE annots ADD COLUMN timestamp_left_ms INT NULL;"))
+        if "timestamp_right_ms" not in columns:
+            conn.execute(text("ALTER TABLE annots ADD COLUMN timestamp_right_ms INT NULL;"))
 
 with app.app_context():
     db.create_all()
+    ensure_schema()
 
 @app.route('/')
 def home():
@@ -39,12 +51,16 @@ def add_annot():
         label=data["label"],
         comments=data.get('comments', ""),
         time=datetime.fromtimestamp(data["time"] / 1000),
-        video_path=os.path.basename(data["video_path"])
+        video_path=os.path.basename(data["video_path"]),
+        timestamp_left_ms=data.get("timestamp_left_ms"),
+        timestamp_right_ms=data.get("timestamp_right_ms")
     ).on_duplicate_key_update(
         sign=data['sign'],
         label=data["label"],
         comments=data.get('comments', ""),
-        time=datetime.fromtimestamp(data["time"] / 1000)
+        time=datetime.fromtimestamp(data["time"] / 1000),
+        timestamp_left_ms=data.get("timestamp_left_ms"),
+        timestamp_right_ms=data.get("timestamp_right_ms")
     )
 
     try:

--- a/flask_app/batches.py
+++ b/flask_app/batches.py
@@ -1,6 +1,7 @@
 import os
 import json
 from flask import Blueprint, jsonify, current_app
+from flask_cors import cross_origin
 
 batches_bp = Blueprint("batches", __name__)
 

--- a/flask_app/models/__init__.py
+++ b/flask_app/models/__init__.py
@@ -13,6 +13,8 @@ class Annot(db.Model):
     time = db.Column(db.TIMESTAMP, default=datetime)
     label = db.Column(db.String(255), nullable=False)
     comments = db.Column(db.Text)
+    timestamp_left_ms = db.Column(db.Integer, nullable=True)
+    timestamp_right_ms = db.Column(db.Integer, nullable=True)
 
 class User(db.Model):
     __tablename__ = "users"


### PR DESCRIPTION
Summary:
I added timestamp_left_ms and timestamp_right_ms columns to the annots table that are added upon running app.py if they don't exist already. I also updated backend /add_annot route to store clip start and end times. I also fixed a bug where comments are persisted between review videos of the same word.

How to test:
Setup annotation engine locally (follow setup.md). Start MySQL and watch as timestamps are saved in table with the annotations and are NULL for all annotations made previous to this change.

- `mysql -u root -p`
- `USE labels;`
- `SELECT * from annots;`

Expected results:
Should see annotations saved in table along with timestamps based on how you change the slider.
<img width="1299" height="55" alt="image" src="https://github.com/user-attachments/assets/f5ef1306-e217-4e3a-84e4-eb2bd2e3b809" />

Design choices:
None